### PR TITLE
Update make instaructions in the install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -54,7 +54,7 @@ install_luaJIT() {
 
     echo "Building luarocks with options: $lua_rocks_configure_options"
     ./configure $lua_rocks_configure_options || exit 1
-    make build || exit 1
+    make build || make || exit 1
     make install || exit 1
   )
 }


### PR DESCRIPTION
I'm getting the following error message when running `asdf install luajit 2.0.5`:

```
make: *** No rule to make target 'build'.  Stop.
```

There's no make command for `build` in the LuatJIT Makefile anymore. Instead, they just instruct to run `make` that evaluates those 3 commands: `cleanup_bins`, `src/luarocks/config.lua`, `build_bins`.

See https://luajit.org/install.html