### PR TITLE
Fetch luajit and luarocks from repositories tags

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,22 +1,32 @@
 #!/usr/bin/env bash
 
-versions_list=(
-  2.0.0--2.4.4
-  2.0.1--2.4.4
-  2.0.2--2.4.4
-  2.0.3--2.4.4
-  2.0.4--2.4.4
-  2.0.5--2.4.4
-  2.1.0-beta1--3.4.0
-  2.1.0-beta2--3.4.0
-  2.1.0-beta3--3.4.0
-)
+set -euo pipefail
 
-versions=""
+list_all_git_tags() {
+  local luajit_tags=( $(list_luajit_git_tags) )
+  local luarocks_tags=( $(list_luarocks_git_tags) )
 
-for version in "${versions_list[@]}"
-do
-  versions="${versions} ${version}"
-done
+  for i in "${!luajit_tags[@]}"; do
+    for j in "${!luarocks_tags[@]}"; do
+      echo "${luajit_tags[i]}--${luarocks_tags[j]}"
+    done
+  done
+}
 
-echo $versions
+list_luajit_git_tags() {
+  list_git_tags https://luajit.org/git/luajit.git
+}
+
+list_luarocks_git_tags() {
+  list_git_tags https://github.com/luarocks/luarocks.git
+}
+
+list_git_tags() {
+  local repo=${1}
+  git ls-remote --tags --refs --sort='v:refname' ${repo} |
+    grep -o 'refs/tags/.*' |
+    cut -d/ -f3- |
+    sed 's/^v//'
+}
+
+list_all_git_tags | xargs echo


### PR DESCRIPTION
Use [`luajit`][0] and [`luarocks`][1] repositories to fetch tag versions and combine them to generate the expected pattern of `<luajit-version>--<luarocks-version>`.

Currently, the solution is naive and generates all the possible combinations between both repositories.

[0]: https://luajit.org/git/luajit.git
[1]: https://github.com/luarocks/luarocks.git