### PR TITLE
Fix luajit install process of rolling versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,11 +32,13 @@ install_luaJIT() {
     make $luaJIT_configure_options || exit 1
     make install $luaJIT_configure_options || exit 1
 
-    # luajit beta versions do not symlink luajit to the built binary,
+    # luajit beta and rolling versions do not symlink luajit to the built binary,
     # so we'll do that manually here, for convenience and also so
     # luarocks can install.
     if [[ $luaJIT_version == *"beta"* ]]; then
       ln -sf luajit-$luaJIT_version $ASDF_INSTALL_PATH/bin/luajit
+    elif [[ $luaJIT_version == *"ROLLING"* ]]; then
+      (cd ${ASDF_INSTALL_PATH}/bin && ln -sf $(ls luajit-* | tail -n 1) luajit)
     fi
 
     ##########################################################################


### PR DESCRIPTION
The `ROLLING` versions of `luajit` do not create the symlink for the `luajit-*` binary, so the script must do it like it's done to `beta` versions.

To test this, install the following version:

```bash
asdf install luajit 2.1.ROLLING--3.11.1
```