### PR TITLE
Hardening

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# shell script settings
+[bin/*]
+indent_style  = space
+indent_size   = 2
+shell_variant = bash

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-plugin_name="luaJIT"
-
 install_path="$(asdf where luajit)"
-full_version="$( echo "$install_path" | rev | cut -d/ -f1 | rev)"
 
 short_lua_version="5.1"
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -3,7 +3,7 @@
 plugin_name="luaJIT"
 
 install_path="$(asdf where luajit)"
-full_version="$( echo $install_path | rev | cut -d/ -f1 | rev)"
+full_version="$( echo "$install_path" | rev | cut -d/ -f1 | rev)"
 
 short_lua_version="5.1"
 

--- a/bin/install
+++ b/bin/install
@@ -1,40 +1,62 @@
 #!/usr/bin/env bash
 
+# We have no need for filename expansion / globbing,
+# so we'll disable it here.
+# We'll take advantage of the safety this confers when doing something like:
+#
+#   confg_args=(--some arg $USER_EXTRA_ARGS)
+#
+# Without set -f, $USER_EXTRA_ARGS can be subject to any glob patterns therein!
+set -f
+
 install_luaJIT() {
   local install_type=$1
   local raw_version=$2
   local install_path=$3
-  local luaJIT_version=$(echo "$raw_version" | sed -e 's/--.*$//g')
-  local lua_rocks_version=$(echo "$raw_version" | sed -e "s/^.*--//g")
+  local luaJIT_version="${raw_version%%--*}"
+  local lua_rocks_version="${raw_version##*--}"
 
   if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir=$(mktemp -d)
+    local tmp_download_dir
+    tmp_download_dir=$(mktemp -d)
   else
-    local tmp_download_dir=$TMPDIR
+    local tmp_download_dir
+    tmp_download_dir=$TMPDIR
   fi
 
-  local luaJIT_source_path=$(get_luaJIT_download_file_path "$install_type" "$luaJIT_version" "$tmp_download_dir")
-  local lua_rocks_source_path=$(get_lua_rocks_download_file_path "$install_type" "$lua_rocks_version" "$tmp_download_dir")
+  local luaJIT_source_path
+  luaJIT_source_path=$(get_luaJIT_download_file_path "$install_type" "$luaJIT_version" "$tmp_download_dir")
+  local lua_rocks_source_path
+  lua_rocks_source_path=$(get_lua_rocks_download_file_path "$install_type" "$lua_rocks_version" "$tmp_download_dir")
   download_luaJIT_source "$install_type" "$luaJIT_version" "$luaJIT_source_path"
   download_lua_rocks_source "$install_type" "$lua_rocks_version" "$lua_rocks_source_path"
 
   # running this in a subshell
   # because we don't want to disturb current working dir
   (
-    cd "${luaJIT_source_path}" || exit
+    local line
 
-    local luaJIT_configure_options="$(construct_luaJIT_configure_options)"
+    cd "${luaJIT_source_path}" || exit 1
+
+    local luaJIT_configure_options=()
+    while IFS='' read -r line; do
+      luaJIT_configure_options+=("$line")
+    done < <(construct_luaJIT_configure_options)
+
     # set in os_based_configure_options
     # we unset it here because echo-ing changes the return value of the function
     unset ASDF_PKG_MISSING
 
     if [[ "$OSTYPE" = "darwin"* ]] && [[ -z "$MACOSX_DEPLOYMENT_TARGET" ]]; then
-      export MACOSX_DEPLOYMENT_TARGET=$(/usr/bin/sw_vers --productVersion)
+      MACOSX_DEPLOYMENT_TARGET=$(/usr/bin/sw_vers --productVersion)
+      export MACOSX_DEPLOYMENT_TARGET
     fi
 
-    echo "Building luaJIT with options: $luaJIT_configure_options"
-    make amalg "$luaJIT_configure_options" || exit 1
-    make install "$luaJIT_configure_options" || exit 1
+    printf "Building luaJIT with options:"
+    printf " %q" "${luaJIT_configure_options[@]}"
+    printf "\n"
+    make amalg "${luaJIT_configure_options[@]}" || exit 1
+    make install "${luaJIT_configure_options[@]}" || exit 1
 
     # luajit beta versions do not symlink luajit to the built binary,
     # so we'll do that manually here, for convenience and also so
@@ -45,61 +67,73 @@ install_luaJIT() {
 
     ##########################################################################
 
-    cd $(dirname "$lua_rocks_source_path") || exit
+    cd "$(dirname "$lua_rocks_source_path")" || exit 1
     tar zxf "$lua_rocks_source_path" || exit 1
-    cd $(untar_lua_rocks_path "$install_type" "$lua_rocks_version" "$tmp_download_dir") || exit
+    cd "$(untar_lua_rocks_path "$install_type" "$lua_rocks_version" "$tmp_download_dir")" || exit
 
-    local lua_rocks_configure_options="$(construct_lua_rocks_configure_options)"
+    local lua_rocks_configure_options=()
+    while IFS='' read -r line; do
+      lua_rocks_configure_options+=("$line")
+    done < <(construct_lua_rocks_configure_options)
+
     # set in os_based_configure_options
     # we unset it here because echo-ing changes the return value of the function
     unset ASDF_PKG_MISSING
 
-    echo "Building luarocks with options: $lua_rocks_configure_options"
-    ./configure "$lua_rocks_configure_options" || exit 1
+    printf "Building luarocks with options:"
+    printf " %q" "${lua_rocks_configure_options[@]}"
+    printf "\n"
+    ./configure "${lua_rocks_configure_options[@]}" || exit 1
     make build || make || exit 1
     make install || exit 1
   )
 }
 
 construct_luaJIT_configure_options() {
-  if [ "$LUAJIT_CONFIGURE_OPTIONS" = "" ]; then
-    local configure_options="$(os_based_luaJIT_configure_options) PREFIX=$install_path"
-
-    if [ "$LUAJIT_EXTRA_CONFIGURE_OPTIONS" != "" ]; then
-      configure_options="$configure_options $LUAJIT_EXTRA_CONFIGURE_OPTIONS"
-    fi
+  local configure_options=()
+  if [ "${LUAJIT_CONFIGURE_OPTIONS:-}" = "" ]; then
+    # we want typical IFS splitting here,
+    # and we've set -f earlier, so this is fine.
+    # shellcheck disable=SC2206
+    configure_options=(
+      PREFIX="$install_path"
+      $LUAJIT_EXTRA_CONFIGURE_OPTIONS 
+    )
   else
-    local configure_options="$LUAJIT_CONFIGURE_OPTIONS PREFIX=$install_path"
+    # shellcheck disable=SC2206
+    configure_options=(
+      $LUAJIT_CONFIGURE_OPTIONS
+      PREFIX="$install_path"
+    )
   fi
 
-  echo "$configure_options"
+  printf "%s\n" "${configure_options[@]}"
 }
 
 construct_lua_rocks_configure_options() {
-  luaJIT_version=$1
   if [ "$LUAROCKS_CONFIGURE_OPTIONS" = "" ]; then
-    local luaJIT_include_version="$(ls "$install_path"/include | head -1)"
-    local luaJIT_include_path="$install_path/include/$luaJIT_include_version"
-    local configure_options="$(os_based_lua_rocks_configure_options) --prefix=$install_path --lua-suffix=jit --with-lua=$install_path --with-lua-include=$luaJIT_include_path"
-
-    if [ "$LUAROCKS_EXTRA_CONFIGURE_OPTIONS" != "" ]; then
-      configure_options="$configure_options $LUAROCKS_EXTRA_CONFIGURE_OPTIONS"
-    fi
+    local luaJIT_include_path
+    luaJIT_include_path="$(find "$install_path"/include -depth 1)"
+    local configure_options=(
+      --prefix="$install_path"
+      --lua-suffix="jit"
+      --with-lua="$install_path"
+      --with-lua-include="$luaJIT_include_path"
+    )
+    # shellcheck disable=SC2206
+    configure_options+=(
+      $LUAROCKS_EXTRA_CONFIGURE_OPTIONS 
+    )
   else
-    local configure_options="$LUAROCKS_CONFIGURE_OPTIONS PREFIX=$install_path"
+    # shellcheck disable=SC2206
+    local configure_options=(
+      $LUAROCKS_CONFIGURE_OPTIONS
+    )
+
+    configure_options+=("PREFIX=$install_path")
   fi
 
-  echo "$configure_options"
-}
-
-os_based_luaJIT_configure_options() {
-  local configure_options=""
-  echo "$configure_options"
-}
-
-os_based_lua_rocks_configure_options() {
-  local configure_options=""
-  echo "$configure_options"
+  printf "%s\n" "${configure_options[@]}"
 }
 
 untar_lua_rocks_path() {
@@ -118,7 +152,8 @@ download_luaJIT_source() {
   local install_type=$1
   local version=$2
   local download_path=$3
-  local download_url=$(get_luaJIT_download_url)
+  local download_url
+  download_url=$(get_luaJIT_download_url)
 
   echo clone luajit from "${download_url}" into "${download_path}"
 
@@ -129,7 +164,8 @@ download_lua_rocks_source() {
   local install_type=$1
   local version=$2
   local download_path=$3
-  local download_url=$(get_lua_rocks_download_url "$install_type" "$version")
+  local download_url
+  download_url=$(get_lua_rocks_download_url "$install_type" "$version")
 
   curl -Lo "$download_path" -C - "$download_url"
 }

--- a/bin/install
+++ b/bin/install
@@ -16,13 +16,20 @@ install_luaJIT() {
   local luaJIT_version="${raw_version%%--*}"
   local lua_rocks_version="${raw_version##*--}"
 
+  local tmp_download_dir
   if [ "$TMPDIR" = "" ]; then
-    local tmp_download_dir
     tmp_download_dir=$(mktemp -d)
   else
-    local tmp_download_dir
     tmp_download_dir=$TMPDIR
   fi
+
+  # canonicalize the path.
+  # this has several benefits:
+  #  1. if the luajit/luarocks build-systems also does this (hint: they do),
+  #     then the path we use here will be guaranteed to be identical.
+  #  2. this removes silly stuff like //, /./ throughout the path,
+  #     and removes a trailing slash (e.g. macOS's $TMPDIR).
+  tmp_download_dir=$(realpath -- "$tmp_download_dir")
 
   local luaJIT_source_path
   luaJIT_source_path=$(get_luaJIT_download_file_path "$install_type" "$luaJIT_version" "$tmp_download_dir")

--- a/bin/install
+++ b/bin/install
@@ -162,9 +162,21 @@ download_luaJIT_source() {
   local download_url
   download_url=$(get_luaJIT_download_url)
 
-  echo clone luajit from "${download_url}" into "${download_path}"
-
-  git clone --branch=v"$version" "$download_url" "$download_path"
+  if ! [[ -d "$download_path" ]]; then
+    echo clone luajit from "${download_url}" into "${download_path}"
+    git clone --branch=v"$version" "$download_url" "$download_path"
+  else
+    if [[ $(git -C "$download_path" remote get-url origin) != $(get_luaJIT_download_url) ]]; then
+      echo "download directory already exists, but does not look like a usable clone" 1>&2
+      echo "download directory: ${download_path}" 1>&2
+      exit 1
+    fi
+    # clean up the directory, and make sure we're on the right branch/tag
+    git -C "$download_path" fetch
+    git -C "$download_path" clean -d -x -f
+    git -C "$download_path" reset --hard
+    git -C "$download_path" checkout v"$version"
+  fi
 }
 
 download_lua_rocks_source() {

--- a/bin/install
+++ b/bin/install
@@ -9,6 +9,9 @@
 # Without set -f, $USER_EXTRA_ARGS can be subject to any glob patterns therein!
 set -f
 
+# fail-fast
+set -euo pipefail
+
 install_luaJIT() {
   local install_type=$1
   local raw_version=$2
@@ -17,7 +20,7 @@ install_luaJIT() {
   local lua_rocks_version="${raw_version##*--}"
 
   local tmp_download_dir
-  if [ "$TMPDIR" = "" ]; then
+  if [[ "${TMPDIR-}" == "" ]]; then
     tmp_download_dir=$(mktemp -d)
   else
     tmp_download_dir=$TMPDIR
@@ -54,7 +57,7 @@ install_luaJIT() {
     # we unset it here because echo-ing changes the return value of the function
     unset ASDF_PKG_MISSING
 
-    if [[ "$OSTYPE" = "darwin"* ]] && [[ -z "$MACOSX_DEPLOYMENT_TARGET" ]]; then
+    if [[ "$OSTYPE" = "darwin"* ]] && [[ -z "${MACOSX_DEPLOYMENT_TARGET-}" ]]; then
       MACOSX_DEPLOYMENT_TARGET=$(/usr/bin/sw_vers --productVersion)
       export MACOSX_DEPLOYMENT_TARGET
     fi
@@ -98,18 +101,18 @@ install_luaJIT() {
 
 construct_luaJIT_configure_options() {
   local configure_options=()
-  if [ "${LUAJIT_CONFIGURE_OPTIONS:-}" = "" ]; then
+  if [[ "${LUAJIT_CONFIGURE_OPTIONS-}" == "" ]]; then
     # we want typical IFS splitting here,
     # and we've set -f earlier, so this is fine.
     # shellcheck disable=SC2206
     configure_options=(
       PREFIX="$install_path"
-      $LUAJIT_EXTRA_CONFIGURE_OPTIONS 
+      ${LUAJIT_EXTRA_CONFIGURE_OPTIONS-}
     )
   else
     # shellcheck disable=SC2206
     configure_options=(
-      $LUAJIT_CONFIGURE_OPTIONS
+      ${LUAJIT_CONFIGURE_OPTIONS-}
       PREFIX="$install_path"
     )
   fi
@@ -118,7 +121,7 @@ construct_luaJIT_configure_options() {
 }
 
 construct_lua_rocks_configure_options() {
-  if [ "$LUAROCKS_CONFIGURE_OPTIONS" = "" ]; then
+  if [[ "${LUAROCKS_CONFIGURE_OPTIONS-}" == "" ]]; then
     local luaJIT_include_path
     luaJIT_include_path="$(find "$install_path"/include -depth 1)"
     local configure_options=(
@@ -129,12 +132,12 @@ construct_lua_rocks_configure_options() {
     )
     # shellcheck disable=SC2206
     configure_options+=(
-      $LUAROCKS_EXTRA_CONFIGURE_OPTIONS 
+      ${LUAROCKS_EXTRA_CONFIGURE_OPTIONS-}
     )
   else
     # shellcheck disable=SC2206
     local configure_options=(
-      $LUAROCKS_CONFIGURE_OPTIONS
+      ${LUAROCKS_CONFIGURE_OPTIONS-}
     )
 
     configure_options+=("PREFIX=$install_path")

--- a/bin/install
+++ b/bin/install
@@ -4,8 +4,8 @@ install_luaJIT() {
   local install_type=$1
   local raw_version=$2
   local install_path=$3
-  local luaJIT_version=$(echo $raw_version | sed -e 's/--.*$//g')
-  local lua_rocks_version=$(echo $raw_version | sed -e "s/^.*--//g")
+  local luaJIT_version=$(echo "$raw_version" | sed -e 's/--.*$//g')
+  local lua_rocks_version=$(echo "$raw_version" | sed -e "s/^.*--//g")
 
   if [ "$TMPDIR" = "" ]; then
     local tmp_download_dir=$(mktemp -d)
@@ -13,15 +13,15 @@ install_luaJIT() {
     local tmp_download_dir=$TMPDIR
   fi
 
-  local luaJIT_source_path=$(get_luaJIT_download_file_path $install_type $luaJIT_version $tmp_download_dir)
-  local lua_rocks_source_path=$(get_lua_rocks_download_file_path $install_type $lua_rocks_version $tmp_download_dir)
-  download_luaJIT_source $install_type $luaJIT_version $luaJIT_source_path
-  download_lua_rocks_source $install_type $lua_rocks_version $lua_rocks_source_path
+  local luaJIT_source_path=$(get_luaJIT_download_file_path "$install_type" "$luaJIT_version" "$tmp_download_dir")
+  local lua_rocks_source_path=$(get_lua_rocks_download_file_path "$install_type" "$lua_rocks_version" "$tmp_download_dir")
+  download_luaJIT_source "$install_type" "$luaJIT_version" "$luaJIT_source_path"
+  download_lua_rocks_source "$install_type" "$lua_rocks_version" "$lua_rocks_source_path"
 
   # running this in a subshell
   # because we don't want to disturb current working dir
   (
-    cd ${luaJIT_source_path}
+    cd "${luaJIT_source_path}" || exit
 
     local luaJIT_configure_options="$(construct_luaJIT_configure_options)"
     # set in os_based_configure_options
@@ -33,21 +33,21 @@ install_luaJIT() {
     fi
 
     echo "Building luaJIT with options: $luaJIT_configure_options"
-    make amalg $luaJIT_configure_options || exit 1
-    make install $luaJIT_configure_options || exit 1
+    make amalg "$luaJIT_configure_options" || exit 1
+    make install "$luaJIT_configure_options" || exit 1
 
     # luajit beta versions do not symlink luajit to the built binary,
     # so we'll do that manually here, for convenience and also so
     # luarocks can install.
     if [[ $luaJIT_version == *"beta"* ]]; then
-      ln -sf luajit-$luaJIT_version $ASDF_INSTALL_PATH/bin/luajit
+      ln -sf luajit-"$luaJIT_version" "$ASDF_INSTALL_PATH"/bin/luajit
     fi
 
     ##########################################################################
 
-    cd $(dirname $lua_rocks_source_path)
-    tar zxf $lua_rocks_source_path || exit 1
-    cd $(untar_lua_rocks_path $install_type $lua_rocks_version $tmp_download_dir)
+    cd $(dirname "$lua_rocks_source_path") || exit
+    tar zxf "$lua_rocks_source_path" || exit 1
+    cd $(untar_lua_rocks_path "$install_type" "$lua_rocks_version" "$tmp_download_dir") || exit
 
     local lua_rocks_configure_options="$(construct_lua_rocks_configure_options)"
     # set in os_based_configure_options
@@ -55,7 +55,7 @@ install_luaJIT() {
     unset ASDF_PKG_MISSING
 
     echo "Building luarocks with options: $lua_rocks_configure_options"
-    ./configure $lua_rocks_configure_options || exit 1
+    ./configure "$lua_rocks_configure_options" || exit 1
     make build || make || exit 1
     make install || exit 1
   )
@@ -78,7 +78,7 @@ construct_luaJIT_configure_options() {
 construct_lua_rocks_configure_options() {
   luaJIT_version=$1
   if [ "$LUAROCKS_CONFIGURE_OPTIONS" = "" ]; then
-    local luaJIT_include_version="$(ls $install_path/include | head -1)"
+    local luaJIT_include_version="$(ls "$install_path"/include | head -1)"
     local luaJIT_include_path="$install_path/include/$luaJIT_include_version"
     local configure_options="$(os_based_lua_rocks_configure_options) --prefix=$install_path --lua-suffix=jit --with-lua=$install_path --with-lua-include=$luaJIT_include_path"
 
@@ -94,12 +94,12 @@ construct_lua_rocks_configure_options() {
 
 os_based_luaJIT_configure_options() {
   local configure_options=""
-  echo $configure_options
+  echo "$configure_options"
 }
 
 os_based_lua_rocks_configure_options() {
   local configure_options=""
-  echo $configure_options
+  echo "$configure_options"
 }
 
 untar_lua_rocks_path() {
@@ -120,18 +120,18 @@ download_luaJIT_source() {
   local download_path=$3
   local download_url=$(get_luaJIT_download_url)
 
-  echo clone luajit from ${download_url} into ${download_path}
+  echo clone luajit from "${download_url}" into "${download_path}"
 
-  git clone --branch=v$version $download_url $download_path
+  git clone --branch=v"$version" "$download_url" "$download_path"
 }
 
 download_lua_rocks_source() {
   local install_type=$1
   local version=$2
   local download_path=$3
-  local download_url=$(get_lua_rocks_download_url $install_type $version)
+  local download_url=$(get_lua_rocks_download_url "$install_type" "$version")
 
-  curl -Lo $download_path -C - $download_url
+  curl -Lo "$download_path" -C - "$download_url"
 }
 
 get_luaJIT_download_file_path() {
@@ -162,4 +162,4 @@ get_lua_rocks_download_url() {
   echo "https://luarocks.github.io/luarocks/releases/luarocks-${version}.tar.gz"
 }
 
-install_luaJIT $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_luaJIT "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,8 +3,17 @@
 set -euo pipefail
 
 list_all_git_tags() {
-  local luajit_tags=( $(list_luajit_git_tags) )
-  local luarocks_tags=( $(list_luarocks_git_tags) )
+  local line
+
+  local luajit_tags=()
+  while IFS='' read -r line; do
+    luajit_tags+=("$line")
+  done < <(list_luajit_git_tags)
+
+  local luarocks_tags=()
+  while IFS='' read -r line; do
+    luarocks_tags+=("$line")
+  done < <(list_luarocks_git_tags)
 
   for i in "${!luajit_tags[@]}"; do
     for j in "${!luarocks_tags[@]}"; do

--- a/bin/list-all
+++ b/bin/list-all
@@ -25,7 +25,7 @@ list_luarocks_git_tags() {
 
 list_git_tags() {
   local repo=${1}
-  git ls-remote --tags --refs --sort='v:refname' ${repo} |
+  git ls-remote --tags --refs --sort='v:refname' "${repo}" |
     grep -o 'refs/tags/.*' |
     cut -d/ -f3- |
     sed 's/^v//'


### PR DESCRIPTION
Alright, this is the first of two relatively big PRs. I figured I'd keep this PR focused solely on hardening and eliminating edge cases, and I'll defer the logic/behavior changes to the second PR.

I tried to keep each commit logically concerned with one thing, hope that helps with review.

At a high level, the changes are:
1. Applied automatic fixes via `shellcheck -f diff * | git apply`
2. Fixed remaining `shellcheck` warnings by hand
3. Added an `.editorconfig` to keep style consistent across contributions
4. Canonicalized the download directory path (a good change on its own, but it plays a larger part in my next PR)
5. Previously when `git clone`ing the repo, if the download directory already existed (e.g. from a previous installation of this version), the `git clone` would fail, but things would mostly/probably work out anyway; now in such cases we skip `git clone` and:
    - Assert that the directory looks like a proper git clone (by sanity checking the remotes)
    - Fetch any remote refs
    - Clean away any files not tracked by `git`
    - Reset the working tree
    - And finally check out the branch (just as a precaution, in case the branch isn't already the branch that the directory name would/should imply
6. The last remaining changes around parameter substitution to allow for setting `set -euo pipefail`, avoiding silently substituting empty variables if we every typo something in future changes (or existing work, for that matter 😄)

I'll see if I can sprinkle some some comments through GitHub's review UI to provide some context on things that might not be terribly intuitive.

As a whole, this should make the code a lot more robust, and the addition of `set -euo pipefail` will make it much harder to introduce any bugs in the future -- not that I anticipate the code changing _too_ much beyond the couple of PRs I'm opening up, but every bit helps I reckon!